### PR TITLE
Add recursion cutoff

### DIFF
--- a/src/StickyContextStack.php
+++ b/src/StickyContextStack.php
@@ -12,6 +12,16 @@ class StickyContextStack
     protected $data = [];
 
     /**
+     * @var int
+     */
+    static $recursionLimit = 5;
+
+    /**
+     * @var int
+     */
+    private $recursionCounter = 0;
+
+    /**
      * Clear the stack of all messages.
      */
     public function flush()
@@ -20,22 +30,28 @@ class StickyContextStack
     }
 
     /**
-     * Retrieve all messages on the stack.
+     * Retrieve all messages on the stack. Prevent recursion beyond the static limit.
      *
      * @return array
      */
     public function all()
     {
-        return array_map(function ($value) {
-            return is_callable($value) ? $value() : $value;
-        }, $this->data);
+        $this->recursionCounter++;
+
+        if ($this->recursionCounter <= static::$recursionLimit) {
+            return array_map(function ($value) {
+                return is_callable($value) ? $value() : $value;
+            }, $this->data);
+        }
+
+        return [];
     }
 
     /**
      * Add context-loggable data to the sticky context.
      *
-     * @param  string  $key
-     * @param  mixed  $data
+     * @param string         $key
+     * @param callable|mixed $data
      */
     public function add(string $key, $data)
     {

--- a/tests/StickyContextStackTest.php
+++ b/tests/StickyContextStackTest.php
@@ -32,4 +32,30 @@ class StickyContextStackTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals([], $stack->all());
     }
+
+    public function test_it_prevents_recursion()
+    {
+        $stack = new StickyContextStack();
+        StickyContextStack::$recursionLimit = 3;
+
+        $counter = 0;
+
+        $stack->add('foo', function () use (&$counter, $stack) {
+           $counter++;
+           return ['counter' => $counter, 'stack' => $stack->all()];
+        });
+
+        $result = $stack->all();
+
+        $this->assertEquals(['foo' => [
+            'counter' => 1,
+            'stack' => ['foo' => [
+                'counter' => 2,
+                'stack' => ['foo' => [
+                    'counter' => 3,
+                    'stack' => [],
+                ]]
+            ]]
+        ]], $result);
+    }
 }


### PR DESCRIPTION
Prevents universe self-destructing because someone had the nerve to call a log event from a sticky-context-invoked code from a log event.

_The nerve, I tell you._